### PR TITLE
Make the Cache system swappable

### DIFF
--- a/src/AudioChord.Caching.GridFS/AudioChord.Caching.GridFS.csproj
+++ b/src/AudioChord.Caching.GridFS/AudioChord.Caching.GridFS.csproj
@@ -1,11 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MongoDB.Driver.GridFS" Version="2.7.3" />
+    <PackageReference Include="MongoDB.Driver.GridFS" Version="2.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AudioChord.Caching.GridFS/AudioChord.Caching.GridFS.csproj
+++ b/src/AudioChord.Caching.GridFS/AudioChord.Caching.GridFS.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MongoDB.Driver.GridFS" Version="2.7.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AudioChord\AudioChord.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/AudioChord.Caching.GridFS/GridFSCache.cs
+++ b/src/AudioChord.Caching.GridFS/GridFSCache.cs
@@ -54,19 +54,18 @@ namespace AudioChord.Caching.GridFS
             }
         }
 
-        public async Task<bool> TryFindCachedSongAsync(SongId id, Action<Stream> result)
+        public async Task<(bool, Stream)> TryFindCachedSongAsync(SongId id)
         {
             // Check if we have the song in the cache
             if (DoesSongIdExist(id))
             {
                 //TODO: Are we gonna clean the cache here?
 
-                result(Stream.Synchronized(await cache.OpenDownloadStreamAsync(id.ToString())));
-                return true;
+                return (true, Stream.Synchronized(await cache.OpenDownloadStreamAsync(id.ToString())));
             }
             else
             {
-                return false;
+                return (false, null);
             }
         }
 

--- a/src/AudioChord.Caching.GridFS/GridFSCache.cs
+++ b/src/AudioChord.Caching.GridFS/GridFSCache.cs
@@ -53,8 +53,8 @@ namespace AudioChord.Caching.GridFS
             {
                 // Update the timestamp of the cache item
                 cleaner.UpdateCacheTimestamp(id);
-                //TODO: Are we gonna clean the cache here?
 
+                // Return the cached Stream
                 return (true, Stream.Synchronized(await cache.OpenDownloadStreamAsync(id.ToString())));
             }
             else

--- a/src/AudioChord.Caching.GridFS/GridFSCache.cs
+++ b/src/AudioChord.Caching.GridFS/GridFSCache.cs
@@ -1,0 +1,86 @@
+﻿using MongoDB.Driver;
+using MongoDB.Driver.GridFS;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+
+namespace AudioChord.Caching.GridFS
+{
+    /// <summary>
+    /// Caches songs to a mongodb GridFS Filesystem
+    /// </summary>
+    public class GridFSCache : ISongCache
+    {
+        const string BUCKET_NAME = "OpusData";
+
+        private GridFSCacheCleaner cleaner;
+
+        protected GridFSBucket<string> cache;
+
+        public GridFSCache(IMongoDatabase database)
+        {
+            cache = new GridFSBucket<string>(database, new GridFSBucketOptions()
+            {
+                BucketName = BUCKET_NAME,
+                ChunkSizeBytes = 4194304,
+
+                // We don't use MD5 in our code
+                DisableMD5 = true
+            });
+
+            cleaner = new GridFSCacheCleaner(cache);
+        }
+
+        /// <summary>
+        /// Cache the <see cref="ISong"/> in the GridFS cache if it doesn't already exist
+        /// </summary>
+        /// <param name="song">The <see cref="ISong"/> to try to cache</param>
+        public async Task CacheSongAsync(ISong song)
+        {
+            // Clean the cache first
+            await cleaner.CleanExpiredCacheEntries();
+
+            // We do not need to upload songs to the cache if they already exist
+            if(!DoesSongIdExist(song.Id))
+            {
+                await cache
+                    .UploadFromStreamAsync(
+                        id: song.Id.ToString(),
+                        filename: $"{song.Id}.opus",
+                        source: await song.GetMusicStreamAsync(),
+                        options: new GridFSUploadOptions() { Metadata = cleaner.GenerateGridFSMetadata() }
+                    );
+            }
+        }
+
+        public async Task<bool> TryFindCachedSongAsync(SongId id, Action<Stream> result)
+        {
+            // Check if we have the song in the cache
+            if (DoesSongIdExist(id))
+            {
+                //TODO: Are we gonna clean the cache here?
+
+                result(Stream.Synchronized(await cache.OpenDownloadStreamAsync(id.ToString())));
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Validate if the <see cref="SongId"/> Exists in the GridFS Cache
+        /// </summary>
+        /// <param name="id">The <see cref="SongId"/> to validate</param>
+        /// <returns>If the <see cref="SongId"/> exists in the GridFS Cache</returns>
+        private bool DoesSongIdExist(SongId id)
+        {
+            FilterDefinitionBuilder<GridFSFileInfo<string>> builder = new FilterDefinitionBuilder<GridFSFileInfo<string>>();
+            var definition = builder.Where(filter => filter.Id == id.ToString());
+
+            return cache.Find(definition).Any();
+        }
+    }
+}

--- a/src/AudioChord.Caching.GridFS/GridFSCacheCleaner.cs
+++ b/src/AudioChord.Caching.GridFS/GridFSCacheCleaner.cs
@@ -1,0 +1,59 @@
+﻿using MongoDB.Bson;
+using MongoDB.Driver;
+using MongoDB.Driver.GridFS;
+using System;
+using System.Threading.Tasks;
+
+namespace AudioChord.Caching.GridFS
+{
+    /// <summary>
+    /// Responsible for cleaning the GridFS Cache when needed
+    /// </summary>
+    internal class GridFSCacheCleaner
+    {
+        private GridFSBucket<string> cache;
+
+        protected IMongoCollection<GridFSFileInfo<string>> files;
+
+        /// <summary>
+        /// The name of the gridfs metadata key that contains the date when the song was last acessed
+        /// </summary>
+        private const string LAST_ACCESS_DATE_KEY = "lastAccessed";
+
+        public GridFSCacheCleaner(GridFSBucket<string> cache)
+        {
+            this.cache = cache;
+            files = cache.Database.GetCollection<GridFSFileInfo<string>>($"{cache.Options.BucketName}.files");
+        }
+
+        public async Task CleanExpiredCacheEntries()
+        {
+            FilterDefinitionBuilder<GridFSFileInfo<string>> builder = new FilterDefinitionBuilder<GridFSFileInfo<string>>();
+
+            // Find all the songs that haven't been used for 3 months
+            // TODO: How are we gonna upgrade all the songs?
+            // BACKCOMPAT: If the song does not have the last used date in the metadata then use the current date
+            FilterDefinition<GridFSFileInfo<string>> definition = builder
+                .Where(filter => filter.Metadata.GetValue(LAST_ACCESS_DATE_KEY, DateTime.Now) < DateTime.Now.AddMonths(-3));
+
+            // Delete a maximum of 100 songs per cleanup operation so we don't wait too long for returning a song
+            foreach(GridFSFileInfo<string> info in cache.Find(definition, new GridFSFindOptions<string>() { Limit = 100 }).ToEnumerable())
+            {
+                await cache.DeleteAsync(info.Id);
+            }
+        }
+
+        public void UpdateCacheTimestamp(SongId id)
+        {
+            var fieldDefinition = new StringFieldDefinition<GridFSFileInfo<string>, BsonDocument>($"metadata.{LAST_ACCESS_DATE_KEY}");
+
+            UpdateDefinitionBuilder<GridFSFileInfo<string>> builder = new UpdateDefinitionBuilder<GridFSFileInfo<string>>();
+            var updateCommand = builder.Set(fieldDefinition, GenerateGridFSMetadata());
+
+            files.UpdateOne(filter => filter.Id == id.ToString(), updateCommand);
+        }
+
+        public BsonDocument GenerateGridFSMetadata() 
+            => new BsonDocument(LAST_ACCESS_DATE_KEY, DateTime.UtcNow);
+    }
+}

--- a/src/AudioChord.Tests/AudioChord.Tests.csproj
+++ b/src/AudioChord.Tests/AudioChord.Tests.csproj
@@ -17,6 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\AudioChord.Caching.GridFS\AudioChord.Caching.GridFS.csproj" />
     <ProjectReference Include="..\AudioChord.Parsers\AudioChord.Parsers.csproj" />
     <ProjectReference Include="..\AudioChord\AudioChord.csproj" />
   </ItemGroup>

--- a/src/AudioChord.Tests/AudioChord.Tests.csproj
+++ b/src/AudioChord.Tests/AudioChord.Tests.csproj
@@ -7,7 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="Moq" Version="4.10.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
@@ -18,7 +19,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\AudioChord.Caching.GridFS\AudioChord.Caching.GridFS.csproj" />
-    <ProjectReference Include="..\AudioChord.Parsers\AudioChord.Parsers.csproj" />
     <ProjectReference Include="..\AudioChord\AudioChord.csproj" />
   </ItemGroup>
 

--- a/src/AudioChord.Tests/GridFSCacheTests.cs
+++ b/src/AudioChord.Tests/GridFSCacheTests.cs
@@ -1,0 +1,91 @@
+﻿using AudioChord.Caching.GridFS;
+using Xunit;
+using Moq;
+using MongoDB.Driver;
+using System.Threading.Tasks;
+using System.IO;
+using MongoDB.Driver.GridFS;
+using System;
+using System.Threading;
+
+namespace AudioChord.Tests
+{
+    public class GridFSCacheTests
+    {
+        private Mock<IMongoDatabase> database;
+        private Mock<IGridFSBucket<string>> bucket;
+        private Mock<IMongoCollection<GridFSFileInfo<string>>> collection;
+
+        private const string LAST_ACCESS_DATE_KEY = "lastAccessed";
+
+        public GridFSCacheTests()
+        {
+            Mock<IMongoCollection<GridFSFileInfo<string>>> mockedFilesCollection = new Mock<IMongoCollection<GridFSFileInfo<string>>>();
+
+            Mock<IMongoDatabase> mockedDatabase = new Mock<IMongoDatabase>();
+            mockedDatabase
+                .Setup(setup => setup.GetCollection<GridFSFileInfo<string>>(It.IsAny<string>(), It.IsAny<MongoCollectionSettings>()))
+                .Returns(mockedFilesCollection.Object);
+
+            Mock<IGridFSBucket<string>> mockedBucket = new Mock<IGridFSBucket<string>>();
+            mockedBucket
+                .Setup(setup => setup.Database)
+                .Returns(mockedDatabase.Object);
+
+            mockedBucket
+                .Setup(setup => setup.Options)
+                .Returns(new ImmutableGridFSBucketOptions());
+
+            FilterDefinition<GridFSFileInfo<string>> definition = new FilterDefinitionBuilder<GridFSFileInfo<string>>()
+                .Where(filter => filter.Metadata.GetValue(LAST_ACCESS_DATE_KEY, DateTime.Now) < DateTime.Now.AddMonths(-3));
+
+            FilterDefinition<GridFSFileInfo<string>> second = new FilterDefinitionBuilder<GridFSFileInfo<string>>()
+                .Where(filter => filter.Metadata.GetValue(LAST_ACCESS_DATE_KEY, DateTime.Now) < DateTime.Now.AddMonths(-3));
+
+            Mock<IAsyncCursor<GridFSFileInfo<string>>> mockedCursor = new Mock<IAsyncCursor<GridFSFileInfo<string>>>();
+            mockedCursor
+                .Setup(setup => setup.MoveNext(It.IsAny<CancellationToken>()))
+                .Returns(false);
+
+            mockedCursor
+                .Setup(setup => setup.MoveNextAsync(It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(false));
+
+            mockedBucket
+                .Setup(setup => setup.Find(It.IsAny<FilterDefinition<GridFSFileInfo<string>>>(), It.IsAny<GridFSFindOptions<string>>(), It.IsAny<CancellationToken>()))
+                .Returns(mockedCursor.Object);
+
+            collection = mockedFilesCollection;
+            database = mockedDatabase;
+            bucket = mockedBucket;
+        }
+
+        [Fact]
+        public async Task GridFSCache_CachesSong()
+        {
+            GridFSCache cache = new GridFSCache(bucket.Object);
+
+            using(MemoryStream fakeStream = new MemoryStream())
+            {
+                SongId id = new SongId("TEST", "592952");
+
+                Mock<ISong> fakeSong = new Mock<ISong>();
+                fakeSong
+                    .Setup(setup => setup.Id)
+                    .Returns(id);
+
+                fakeSong
+                    .Setup(setup => setup.GetMusicStreamAsync())
+                    .Returns(Task.FromResult<Stream>(fakeStream));
+
+                await cache.CacheSongAsync(fakeSong.Object);
+
+                (bool result, Stream stream) = await cache.TryFindCachedSongAsync(id);
+
+                // Check that the cache returned the same song
+                Assert.True(result);
+                Assert.Same(fakeStream, stream);
+            }
+        }
+    }
+}

--- a/src/AudioChord.Tests/PlayListsTests.cs
+++ b/src/AudioChord.Tests/PlayListsTests.cs
@@ -1,5 +1,6 @@
 using AudioChord.Caching.GridFS;
 using MongoDB.Driver;
+using MongoDB.Driver.GridFS;
 using System;
 using System.Threading.Tasks;
 using Xunit;
@@ -22,10 +23,18 @@ namespace AudioChord.Tests
             MongoClient client = new MongoClient(connectionStringBuilder.ToMongoUrl());
             IMongoDatabase database = client.GetDatabase("sharedmusic");
 
+            const string BUCKET_NAME = "OpusData";
 
             service = new MusicService(new MusicServiceConfiguration()
             {
-                SongCacheFactory = () => new GridFSCache(database)
+                SongCacheFactory = () => new GridFSCache(new GridFSBucket<string>(database, new GridFSBucketOptions()
+                {
+                    BucketName = BUCKET_NAME,
+                    ChunkSizeBytes = 4194304,
+
+                    // We don't use MD5 in our code
+                    DisableMD5 = true
+                }))
             });
         }
 

--- a/src/AudioChord.Tests/PlayListsTests.cs
+++ b/src/AudioChord.Tests/PlayListsTests.cs
@@ -1,3 +1,5 @@
+using AudioChord.Caching.GridFS;
+using MongoDB.Driver;
 using System;
 using System.Threading.Tasks;
 using Xunit;
@@ -10,8 +12,20 @@ namespace AudioChord.Tests
 
         public PlaylistTests()
         {
+            // Use the builder to allow to connect to database without authentication
+            MongoUrlBuilder connectionStringBuilder = new MongoUrlBuilder
+            {
+                DatabaseName = "sharedmusic",
+                Server = new MongoServerAddress("localhost")
+            };
+
+            MongoClient client = new MongoClient(connectionStringBuilder.ToMongoUrl());
+            IMongoDatabase database = client.GetDatabase("sharedmusic");
+
+
             service = new MusicService(new MusicServiceConfiguration()
             {
+                SongCacheFactory = () => new GridFSCache(database)
             });
         }
 

--- a/src/AudioChord.sln
+++ b/src/AudioChord.sln
@@ -7,7 +7,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AudioChord", "AudioChord\Au
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AudioChord.Tests", "AudioChord.Tests\AudioChord.Tests.csproj", "{F1D9A431-F3B0-4CD0-B38D-1046BE0269E0}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AudioChord.Parsers", "AudioChord.Parsers\AudioChord.Parsers.csproj", "{C6F1BACA-F4AD-48CA-8974-C8B4A9A83C42}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AudioChord.Parsers", "AudioChord.Parsers\AudioChord.Parsers.csproj", "{C6F1BACA-F4AD-48CA-8974-C8B4A9A83C42}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AudioChord.Caching.GridFS", "AudioChord.Caching.GridFS\AudioChord.Caching.GridFS.csproj", "{F1EC2B7E-6759-41C0-89BD-C1BDE7D7FED2}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -27,6 +29,10 @@ Global
 		{C6F1BACA-F4AD-48CA-8974-C8B4A9A83C42}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C6F1BACA-F4AD-48CA-8974-C8B4A9A83C42}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C6F1BACA-F4AD-48CA-8974-C8B4A9A83C42}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F1EC2B7E-6759-41C0-89BD-C1BDE7D7FED2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F1EC2B7E-6759-41C0-89BD-C1BDE7D7FED2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F1EC2B7E-6759-41C0-89BD-C1BDE7D7FED2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F1EC2B7E-6759-41C0-89BD-C1BDE7D7FED2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/AudioChord/Caching/ISongCache.cs
+++ b/src/AudioChord/Caching/ISongCache.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace AudioChord.Caching
+{
+    /// <summary>
+    /// A service for caching downloaded songs
+    /// </summary>
+    public interface ISongCache
+    {
+        Task<bool> TryFindCachedSongAsync(SongId id, Action<Stream> result);
+        Task CacheSongAsync(ISong song);
+    }
+}

--- a/src/AudioChord/Caching/ISongCache.cs
+++ b/src/AudioChord/Caching/ISongCache.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.Threading.Tasks;
 
 namespace AudioChord.Caching
@@ -9,7 +8,7 @@ namespace AudioChord.Caching
     /// </summary>
     public interface ISongCache
     {
-        Task<bool> TryFindCachedSongAsync(SongId id, Action<Stream> result);
+        Task<(bool success, Stream result)> TryFindCachedSongAsync(SongId id);
         Task CacheSongAsync(ISong song);
     }
 }

--- a/src/AudioChord/MusicServiceConfiguration.cs
+++ b/src/AudioChord/MusicServiceConfiguration.cs
@@ -1,7 +1,13 @@
-﻿namespace AudioChord
+﻿using AudioChord.Caching;
+using System;
+
+namespace AudioChord
 {
     public class MusicServiceConfiguration
     {
+        public Func<ISongCache> SongCacheFactory { get; set; }
+
+
         public string Username { get; set; }
         public string Password { get; set; }
         public string Hostname { get; set; } = "localhost";


### PR DESCRIPTION
Audiochord is currently hard-coded to use Mongodb for handling and storing music (meta)data. 

It is probably a good idea to allow different implementations if required. This pull request starts the work by abstracting the cache over an interface. And moving the Implementation to a separate project.

there are a few important things though:
- All music metadata is now *directly inside the GridFS file. not in a separate collection.*
- We need to upgrade the data inside the current database with an upgrade script.