### PR TITLE
Add in-memory cache

### DIFF
--- a/src/AudioChord/Caching/InMemory/InMemoryCache.cs
+++ b/src/AudioChord/Caching/InMemory/InMemoryCache.cs
@@ -1,0 +1,18 @@
+using System.IO;
+using System.Threading.Tasks;
+
+namespace AudioChord.Caching.InMemory
+{
+    public class InMemoryCache : ISongCache
+    {
+        public Task<(bool success, Stream result)> TryFindCachedSongAsync(SongId id)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public Task CacheSongAsync(ISong song)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/src/AudioChord/Caching/InMemory/InMemoryCache.cs
+++ b/src/AudioChord/Caching/InMemory/InMemoryCache.cs
@@ -1,18 +1,27 @@
+using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 
 namespace AudioChord.Caching.InMemory
 {
+    /// <summary>
+    /// A Memory-based cache. This can be used for testing purposes or as a temporary solution
+    /// </summary>
     public class InMemoryCache : ISongCache
     {
+        private Dictionary<SongId, Stream> _cache = new Dictionary<SongId, Stream>();
+        
         public Task<(bool success, Stream result)> TryFindCachedSongAsync(SongId id)
         {
-            throw new System.NotImplementedException();
+            if (_cache.TryGetValue(id, out Stream stream))
+                return Task.FromResult((true, stream));
+
+            return Task.FromResult<(bool success, Stream result)>((false, Stream.Null));
         }
 
-        public Task CacheSongAsync(ISong song)
+        public async Task CacheSongAsync(ISong song)
         {
-            throw new System.NotImplementedException();
+            _cache.Add(song.Id, await song.GetMusicStreamAsync());
         }
     }
 }


### PR DESCRIPTION
This pull request adds a simple in-memory cache as a replacement when debugging a problem and not wanting to set up an entire database or directory.

The cache does not get persisted and will be gone when restarting the application