### PR TITLE
Configure max song duration in MusicService.

### DIFF
--- a/src/AudioChord.sln
+++ b/src/AudioChord.sln
@@ -13,6 +13,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AudioChord.Caching.GridFS",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AudioChord.Caching.FileSystem", "AudioChord.Caching.FileSystem\AudioChord.Caching.FileSystem.csproj", "{36C85735-544B-48F8-BF62-F96257DB63F7}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Caching implementations", "Caching implementations", "{B08D37AF-CD0B-4DAF-B63F-F97BA1EB240C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -45,5 +47,9 @@ Global
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6E094757-65B9-411E-B76D-AEB82EA78A68}
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{36C85735-544B-48F8-BF62-F96257DB63F7} = {B08D37AF-CD0B-4DAF-B63F-F97BA1EB240C}
+		{F1EC2B7E-6759-41C0-89BD-C1BDE7D7FED2} = {B08D37AF-CD0B-4DAF-B63F-F97BA1EB240C}
 	EndGlobalSection
 EndGlobal

--- a/src/AudioChord/Collections/SongCollection.cs
+++ b/src/AudioChord/Collections/SongCollection.cs
@@ -132,7 +132,7 @@ namespace AudioChord.Collections
         {
             // Build the corresponding id
             string youtubeVideoId = YoutubeClient.ParseVideoId(url);
-            SongId id = new SongId(YouTubeProcessor.ProcessorPrefix, youtubeVideoId);
+            SongId id = new SongId(YouTubeExtractor.ProcessorPrefix, youtubeVideoId);
 
             // Check if the song is already cached, the same youtube video can be downloaded twice
             (bool isCached, ISong song) = await TryGetSongAsync(id);
@@ -140,7 +140,7 @@ namespace AudioChord.Collections
                 return song;
 
             // Not in the cache, extract the audio from the url
-            IAudioExtractor extractor = new YouTubeProcessor();
+            IAudioExtractor extractor = new YouTubeExtractor();
             ISong directlyDownloaded = await extractor.ExtractAsync(url, configuration);
 
             // Cache the song so that we do not need to download it again

--- a/src/AudioChord/Extractors/ExtractorConfiguration.cs
+++ b/src/AudioChord/Extractors/ExtractorConfiguration.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace AudioChord.Extractors
+{
+    public class ExtractorConfiguration
+    {
+        public TimeSpan MaxSongDuration { get; set; } = TimeSpan.FromHours(1);
+    }
+}

--- a/src/AudioChord/Extractors/IAudioExtractor.cs
+++ b/src/AudioChord/Extractors/IAudioExtractor.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+
+namespace AudioChord.Extractors
+{
+    public interface IAudioExtractor
+    {
+        Task<ISong> ExtractAsync(string url, ExtractorConfiguration configuration);
+    }
+}

--- a/src/AudioChord/Extractors/YouTubeExtractor.cs
+++ b/src/AudioChord/Extractors/YouTubeExtractor.cs
@@ -2,17 +2,17 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using AudioChord.Extractors;
+using AudioChord.Processors;
 using YoutubeExplode;
 using YoutubeExplode.Models;
 using YoutubeExplode.Models.MediaStreams;
 
-namespace AudioChord.Processors
+namespace AudioChord.Extractors
 {
     /// <summary>
     /// Extracts audio from youtube videos
     /// </summary>
-    internal class YouTubeProcessor : IAudioExtractor
+    internal class YouTubeExtractor : IAudioExtractor
     {
         private readonly YoutubeClient _client = new YoutubeClient();
         private readonly FFmpegEncoder _encoder = new FFmpegEncoder();

--- a/src/AudioChord/Facades/DiscordProcessorFacade.cs
+++ b/src/AudioChord/Facades/DiscordProcessorFacade.cs
@@ -1,14 +1,14 @@
 ﻿using System;
-using AudioChord.Collections;
 using System.Threading.Tasks;
+using AudioChord.Collections;
 
-namespace AudioChord.Wrappers
+namespace AudioChord.Facades
 {
-    public class DiscordProcessorWrapper
+    public class DiscordProcessorFacade
     {
         private readonly SongCollection _songCollection;
 
-        internal DiscordProcessorWrapper(SongCollection song)
+        internal DiscordProcessorFacade(SongCollection song)
         {
             _songCollection = song;
         }

--- a/src/AudioChord/Facades/YoutubeProcessorFacade.cs
+++ b/src/AudioChord/Facades/YoutubeProcessorFacade.cs
@@ -56,12 +56,7 @@ namespace AudioChord.Facades
         /// <exception cref="FormatException">The url given was not a valid youtube url</exception>
         /// <exception cref="InvalidOperationException">The processed song was empty</exception>
         public Task<ISong> DownloadAsync(Uri url)
-        {
-            if (YoutubeClient.TryParseVideoId(url.ToString(), out string id))
-                return _songCollection.DownloadFromYouTubeAsync(id);
-
-            throw new FormatException("Invalid youtube video URL");
-        }
+            => _songCollection.DownloadFromYouTubeAsync(url.ToString(), _extractorConfiguration);
 
         /// <summary>
         /// Capture Youtube Video Id

--- a/src/AudioChord/Facades/YoutubeProcessorFacade.cs
+++ b/src/AudioChord/Facades/YoutubeProcessorFacade.cs
@@ -12,31 +12,28 @@ namespace AudioChord.Facades
     {
         private readonly SongCollection _songCollection;
         private readonly PlaylistProcessor _playlistProcessor;
-        private readonly ExtractorConfiguration _extractorConfiguration;
+        private readonly ExtractorConfiguration _defaultExtractorConfiguration;
 
         internal YoutubeProcessorFacade(SongCollection songStorage, PlaylistProcessor processor, ExtractorConfiguration configuration)
         {
             _songCollection = songStorage;
             _playlistProcessor = processor;
-            _extractorConfiguration = configuration;
+            _defaultExtractorConfiguration = configuration;
         }
-
+        
         /// <summary>
         /// Download a list of YT songs to database (without progress).
         /// </summary>
-        /// /// <param name="playlistLocation">The url where the playlist is located</param>
-        public Task<ResolvingPlaylist> DownloadPlaylistAsync(Uri playlistLocation)
-            => _playlistProcessor.ProcessPlaylist(playlistLocation, null, CancellationToken.None);
-
-        /// <summary>
-        /// Download a list of YT songs to database.
-        /// </summary>
         /// <param name="playlistLocation">The url where the playlist is located</param>
-        /// <param name="progress">Callback for reporting progress on song processing</param>
-        [Obsolete("Use the overload with CancellationToken instead")]
-        public Task<ResolvingPlaylist> DownloadPlaylistAsync(Uri playlistLocation,
-            IProgress<SongProcessStatus> progress)
-            => _playlistProcessor.ProcessPlaylist(playlistLocation, progress, CancellationToken.None);
+        /// <param name="configuration">
+        ///     a custom extractor configuration.
+        ///     if none is provided then the default settings of the <see cref="MusicServiceConfiguration"/> will be used
+        /// </param>
+        public Task<ResolvingPlaylist> DownloadPlaylistAsync(
+                Uri playlistLocation, 
+                ExtractorConfiguration configuration = null
+            )
+            => DownloadPlaylistAsync(playlistLocation, null, CancellationToken.None, configuration);
 
         /// <summary>
         /// Download a list of YT songs to database.
@@ -44,19 +41,38 @@ namespace AudioChord.Facades
         /// <param name="playlistLocation">The url where the playlist is located</param>
         /// <param name="progress">Callback for reporting progress on song processing</param>
         /// <param name="token">CancellationToken to stop processing of songs in the playlist</param>
-        public Task<ResolvingPlaylist> DownloadPlaylistAsync(Uri playlistLocation,
-            IProgress<SongProcessStatus> progress, CancellationToken token)
-            => _playlistProcessor.ProcessPlaylist(playlistLocation, progress, token);
+        /// <param name="configuration">
+        ///     a custom extractor configuration.
+        ///     if none is provided then the default settings of the <see cref="MusicServiceConfiguration"/> will be used
+        /// </param>
+        public Task<ResolvingPlaylist> DownloadPlaylistAsync(
+            Uri playlistLocation,
+            IProgress<SongProcessStatus> progress, 
+            CancellationToken token,
+            ExtractorConfiguration configuration = null)
+        {
+            ExtractorConfiguration actualConfiguration = configuration ?? _defaultExtractorConfiguration;
+            
+            return _playlistProcessor.ProcessPlaylist(playlistLocation, progress, token, actualConfiguration);
+        }
 
         /// <summary>
         /// Download song from YouTube to database. (Note: Exceptions are to be expected.)
         /// </summary>
         /// <param name="url">The youtube video url.</param>
+        /// <param name="configuration">
+        ///     a custom extractor configuration.
+        ///     if none is provided then the default settings of the <see cref="MusicServiceConfiguration"/> will be used
+        /// </param>
         /// <returns>A new <see cref="ISong"/> with the audio of the youtube video</returns>
         /// <exception cref="FormatException">The url given was not a valid youtube url</exception>
         /// <exception cref="InvalidOperationException">The processed song was empty</exception>
-        public Task<ISong> DownloadAsync(Uri url)
-            => _songCollection.DownloadFromYouTubeAsync(url.ToString(), _extractorConfiguration);
+        public Task<ISong> DownloadAsync(Uri url, ExtractorConfiguration configuration = null)
+        {
+            ExtractorConfiguration actualConfig = configuration ?? _defaultExtractorConfiguration;
+            
+            return _songCollection.DownloadFromYouTubeAsync(url.ToString(), actualConfig);
+        }
 
         /// <summary>
         /// Capture Youtube Video Id

--- a/src/AudioChord/Facades/YoutubeProcessorFacade.cs
+++ b/src/AudioChord/Facades/YoutubeProcessorFacade.cs
@@ -1,21 +1,24 @@
-﻿using AudioChord.Collections;
-using AudioChord.Processors;
-using System;
+﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
+using AudioChord.Collections;
+using AudioChord.Extractors;
+using AudioChord.Processors;
 using YoutubeExplode;
 
-namespace AudioChord.Wrappers
+namespace AudioChord.Facades
 {
-    public class YoutubeProcessorWrapper
+    public class YoutubeProcessorFacade
     {
         private readonly SongCollection _songCollection;
         private readonly PlaylistProcessor _playlistProcessor;
+        private readonly ExtractorConfiguration _extractorConfiguration;
 
-        internal YoutubeProcessorWrapper(SongCollection songStorage, PlaylistProcessor processor)
+        internal YoutubeProcessorFacade(SongCollection songStorage, PlaylistProcessor processor, ExtractorConfiguration configuration)
         {
             _songCollection = songStorage;
             _playlistProcessor = processor;
+            _extractorConfiguration = configuration;
         }
 
         /// <summary>

--- a/src/AudioChord/MusicService.cs
+++ b/src/AudioChord/MusicService.cs
@@ -45,8 +45,7 @@ namespace AudioChord
             Youtube = new YoutubeProcessorFacade(
                 _songCollection, 
                 new PlaylistProcessor(
-                    _songCollection, 
-                    config.ExtractorConfiguration, 
+                    _songCollection,
                     this
                 ),
                 config.ExtractorConfiguration

--- a/src/AudioChord/MusicService.cs
+++ b/src/AudioChord/MusicService.cs
@@ -1,11 +1,11 @@
 ﻿using AudioChord.Collections;
 using AudioChord.Processors;
-using AudioChord.Wrappers;
 using MongoDB.Bson.Serialization;
 using MongoDB.Driver;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using AudioChord.Exceptions;
+using AudioChord.Facades;
 
 namespace AudioChord
 {
@@ -18,8 +18,8 @@ namespace AudioChord
 
         private readonly SongCollection _songCollection;
 
-        public YoutubeProcessorWrapper Youtube { get; }
-        public DiscordProcessorWrapper Discord { get; }
+        public YoutubeProcessorFacade Youtube { get; }
+        public DiscordProcessorFacade Discord { get; }
         public PlaylistCollection Playlist { get; }
 
         public MusicService(MusicServiceConfiguration config)
@@ -41,9 +41,14 @@ namespace AudioChord
 
             Playlist = new PlaylistCollection(database, _songCollection);
 
-            // Processor wrappers
-            Youtube = new YoutubeProcessorWrapper(_songCollection, new PlaylistProcessor(_songCollection, this));
-            Discord = new DiscordProcessorWrapper(_songCollection);
+            // Processor facades
+            Youtube = new YoutubeProcessorFacade(
+                _songCollection, 
+                new PlaylistProcessor(_songCollection, this),
+                config.ExtractorConfiguration
+            );
+            
+            Discord = new DiscordProcessorFacade(_songCollection);
         }
 
         /// <summary>

--- a/src/AudioChord/MusicService.cs
+++ b/src/AudioChord/MusicService.cs
@@ -44,7 +44,11 @@ namespace AudioChord
             // Processor facades
             Youtube = new YoutubeProcessorFacade(
                 _songCollection, 
-                new PlaylistProcessor(_songCollection, this),
+                new PlaylistProcessor(
+                    _songCollection, 
+                    config.ExtractorConfiguration, 
+                    this
+                ),
                 config.ExtractorConfiguration
             );
             

--- a/src/AudioChord/MusicServiceConfiguration.cs
+++ b/src/AudioChord/MusicServiceConfiguration.cs
@@ -1,8 +1,12 @@
 ﻿using AudioChord.Caching;
+using AudioChord.Extractors;
 using System;
 
 namespace AudioChord
 {
+    /// <summary>
+    /// Configuration object for the music service
+    /// </summary>
     public class MusicServiceConfiguration
     {
         public Func<ISongCache> SongCacheFactory { get; set; }
@@ -13,5 +17,7 @@ namespace AudioChord
 
         // ReSharper disable once StringLiteralTypo
         public string Database { get; internal set; } = "sharedmusic";
+        
+        public ExtractorConfiguration ExtractorConfiguration { get; set; } = new ExtractorConfiguration();
     }
 }

--- a/src/AudioChord/Processors/PlaylistProcessor.cs
+++ b/src/AudioChord/Processors/PlaylistProcessor.cs
@@ -5,6 +5,8 @@ using System.Collections.Generic;
 using System.Collections.Concurrent;
 using System.Threading.Tasks;
 using System.Threading;
+using AudioChord.Extractors;
+using YoutubeExplode;
 
 namespace AudioChord.Processors
 {
@@ -14,13 +16,16 @@ namespace AudioChord.Processors
         private readonly MusicService _musicService;
         private readonly WorkScheduler _scheduler;
 
-        private readonly ConcurrentDictionary<SongId, Task<ISong>> _allWork =
-            new ConcurrentDictionary<SongId, Task<ISong>>();
+        private ExtractorConfiguration _configuration;
 
-        public PlaylistProcessor(SongCollection song, MusicService service)
+        private readonly ConcurrentDictionary<string, Task<ISong>> _allWork =
+            new ConcurrentDictionary<string, Task<ISong>>();
+
+        public PlaylistProcessor(SongCollection song, ExtractorConfiguration configuration, MusicService service)
         {
             _songCollection = song;
             _musicService = service;
+            _configuration = configuration;
             _scheduler = new WorkScheduler();
         }
 
@@ -33,10 +38,11 @@ namespace AudioChord.Processors
             Queue<StartableTask<ISong>> backlog = new Queue<StartableTask<ISong>>();
 
             //WARNING: Only one thread should be able to verify if songs are in the database
-            foreach (string id in await processor.ParsePlaylistAsync(playlistLocation))
+            foreach (string url in await processor.ParsePlaylistAsync(playlistLocation))
             {
+                string videoId = YoutubeClient.ParseVideoId(url);
                 // Convert the id to a SongId
-                SongId songId = new SongId(YouTubeProcessor.ProcessorPrefix, id);
+                SongId songId = new SongId(YouTubeProcessor.ProcessorPrefix, videoId);
 
                 // Check if the song already exists in the database
                 if (_songCollection.CheckAlreadyExists(songId))
@@ -52,18 +58,21 @@ namespace AudioChord.Processors
                     // Song does not exist, add a placeholder that gives back the actual song when done
                     playlist.Songs.Add(
                         // Check if a placeholder already exists
-                        _allWork.GetOrAdd(songId, processingSongId =>
+                        _allWork.GetOrAdd(url, songUrl =>
                         {
                             // Always add progress reporting, there is a possibility that somebody who wants reports attaches later
                             StartableTask<ISong> work = new StartableTask<ISong>(()
                                 => AddProgressReporting(
-                                    _songCollection.DownloadFromYouTubeAsync(processingSongId.SourceId), progress,
-                                    processingSongId));
+                                        _songCollection.DownloadFromYouTubeAsync(songUrl, _configuration), 
+                                        progress,
+                                        songId
+                                    )
+                                );
 
                             backlog.Enqueue(work);
 
                             // Remove the task from the dictionary when it's done
-                            work.Work.ContinueWith(task => { _allWork.TryRemove(processingSongId, out _); }, token);
+                            work.Work.ContinueWith(task => { _allWork.TryRemove(songUrl, out _); }, token);
 
                             return work.Work;
                         })

--- a/src/AudioChord/Processors/PlaylistProcessor.cs
+++ b/src/AudioChord/Processors/PlaylistProcessor.cs
@@ -16,21 +16,22 @@ namespace AudioChord.Processors
         private readonly MusicService _musicService;
         private readonly WorkScheduler _scheduler;
 
-        private ExtractorConfiguration _configuration;
-
         private readonly ConcurrentDictionary<string, Task<ISong>> _allWork =
             new ConcurrentDictionary<string, Task<ISong>>();
 
-        public PlaylistProcessor(SongCollection song, ExtractorConfiguration configuration, MusicService service)
+        public PlaylistProcessor(SongCollection song, MusicService service)
         {
             _songCollection = song;
             _musicService = service;
-            _configuration = configuration;
             _scheduler = new WorkScheduler();
         }
 
-        public async Task<ResolvingPlaylist> ProcessPlaylist(Uri playlistLocation,
-            IProgress<SongProcessStatus> progress, CancellationToken token)
+        public async Task<ResolvingPlaylist> ProcessPlaylist(
+                Uri playlistLocation,
+                IProgress<SongProcessStatus> progress, 
+                CancellationToken token,
+                ExtractorConfiguration configuration
+            )
         {
             YouTubeExtractor extractor = new YouTubeExtractor();
             ResolvingPlaylist playlist = new ResolvingPlaylist(ObjectId.GenerateNewId().ToString());
@@ -63,7 +64,7 @@ namespace AudioChord.Processors
                             // Always add progress reporting, there is a possibility that somebody who wants reports attaches later
                             StartableTask<ISong> work = new StartableTask<ISong>(()
                                 => AddProgressReporting(
-                                        _songCollection.DownloadFromYouTubeAsync(songUrl, _configuration), 
+                                        _songCollection.DownloadFromYouTubeAsync(songUrl, configuration), 
                                         progress,
                                         songId
                                     )

--- a/src/AudioChord/Processors/PlaylistProcessor.cs
+++ b/src/AudioChord/Processors/PlaylistProcessor.cs
@@ -32,17 +32,17 @@ namespace AudioChord.Processors
         public async Task<ResolvingPlaylist> ProcessPlaylist(Uri playlistLocation,
             IProgress<SongProcessStatus> progress, CancellationToken token)
         {
-            YouTubeProcessor processor = new YouTubeProcessor();
+            YouTubeExtractor extractor = new YouTubeExtractor();
             ResolvingPlaylist playlist = new ResolvingPlaylist(ObjectId.GenerateNewId().ToString());
 
             Queue<StartableTask<ISong>> backlog = new Queue<StartableTask<ISong>>();
 
             //WARNING: Only one thread should be able to verify if songs are in the database
-            foreach (string url in await processor.ParsePlaylistAsync(playlistLocation))
+            foreach (string url in await extractor.ParsePlaylistAsync(playlistLocation))
             {
                 string videoId = YoutubeClient.ParseVideoId(url);
                 // Convert the id to a SongId
-                SongId songId = new SongId(YouTubeProcessor.ProcessorPrefix, videoId);
+                SongId songId = new SongId(YouTubeExtractor.ProcessorPrefix, videoId);
 
                 // Check if the song already exists in the database
                 if (_songCollection.CheckAlreadyExists(songId))

--- a/src/AudioChord/Processors/YouTubeProcessor.cs
+++ b/src/AudioChord/Processors/YouTubeProcessor.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using AudioChord.Extractors;
 using YoutubeExplode;
 using YoutubeExplode.Models;
 using YoutubeExplode.Models.MediaStreams;
@@ -9,23 +10,20 @@ using YoutubeExplode.Models.MediaStreams;
 namespace AudioChord.Processors
 {
     /// <summary>
-    /// Convert youtube url links to opus audio data
+    /// Extracts audio from youtube videos
     /// </summary>
-    internal class YouTubeProcessor
+    internal class YouTubeProcessor : IAudioExtractor
     {
         private readonly YoutubeClient _client = new YoutubeClient();
         private readonly FFmpegEncoder _encoder = new FFmpegEncoder();
 
         public static string ProcessorPrefix { get; } = "YOUTUBE";
-
-        private async Task<SongMetadata> GetVideoMetadataAsync(string youtubeVideoId)
+        
+        public Task<ISong> ExtractAsync(string url, ExtractorConfiguration configuration)
         {
-            Video videoInfo = await _client.GetVideoAsync(youtubeVideoId);
-
-            if (videoInfo.Duration.TotalMinutes > 15.0)
-                throw new ArgumentOutOfRangeException(nameof(youtubeVideoId), "Video duration longer than 15 minutes!");
-
-            return new SongMetadata(videoInfo.Title, videoInfo.Duration, videoInfo.Author, videoInfo.GetShortUrl());
+            string id = YoutubeClient.ParseVideoId(url);
+            
+            return ExtractSongAsync(id, configuration.MaxSongDuration);
         }
 
         /// <summary>
@@ -33,24 +31,41 @@ namespace AudioChord.Processors
         /// </summary>
         /// <exception cref="ArgumentException">The videoId passed to this method is not a valid youtube video id</exception>
         /// <returns>A new <see cref="Song"/> with metadata of the Youtube video</returns>
-        internal async Task<ISong> ExtractSongAsync(string videoId)
+        [Obsolete("Use the IAudioExtractor processing instead")]
+        internal Task<ISong> ExtractSongAsync(string videoId)
+        {
+            return ExtractSongAsync(videoId, TimeSpan.FromMinutes(15));
+        }
+
+        private async Task<ISong> ExtractSongAsync(string videoId, TimeSpan maximumDuration)
         {
             if (!YoutubeClient.ValidateVideoId(videoId))
                 throw new ArgumentException("The videoId is not correctly formatted");
 
-            //retrieve the metadata of the video
+            // Retrieve the metadata of the video
             SongMetadata metadata = await GetVideoMetadataAsync(videoId);
 
-            //retrieve the actual video and convert it to opus
+            if (metadata.Length > maximumDuration)
+                throw new ArgumentOutOfRangeException(nameof(videoId), "Video duration longer than 15 minutes!");
+
+            // Retrieve the actual video and convert it to opus
             MuxedStreamInfo streamInfo =
                 (await _client.GetVideoMediaStreamInfosAsync(videoId)).Muxed.WithHighestVideoQuality();
+            
             using (MediaStream youtubeStream = await _client.GetMediaStreamAsync(streamInfo))
             {
-                //convert it to a Song class
-                //the processor should be responsible for prefixing the id with the correct type
+                // Convert it to a Song class
+                // The processor should be responsible for prefixing the id with the correct type
                 return new Song(new SongId(ProcessorPrefix, videoId), metadata,
                     await _encoder.ProcessAsync(youtubeStream));
             }
+        }
+        
+        private async Task<SongMetadata> GetVideoMetadataAsync(string youtubeVideoId)
+        {
+            Video videoInfo = await _client.GetVideoAsync(youtubeVideoId);
+
+            return new SongMetadata(videoInfo.Title, videoInfo.Duration, videoInfo.Author, videoInfo.GetShortUrl());
         }
 
         /// <summary>

--- a/src/AudioChord/Processors/YouTubeProcessor.cs
+++ b/src/AudioChord/Processors/YouTubeProcessor.cs
@@ -79,7 +79,7 @@ namespace AudioChord.Processors
                 throw new ArgumentNullException(nameof(playlistLocation), "The uri passed to this method is null");
 
             if (!YoutubeClient.TryParsePlaylistId(playlistLocation.ToString(), out string playlistId))
-                throw new ArgumentException("Invalid playlist url given");
+                throw new ArgumentException("Invalid playlist url given", nameof(playlistLocation));
 
             YoutubeExplode.Models.Playlist playlist = await _client.GetPlaylistAsync(playlistId);
 
@@ -87,7 +87,7 @@ namespace AudioChord.Processors
             return playlist.Videos
                 .ToList()
                 //create tasks out of all the videos
-                .ConvertAll(video => video.Id);
+                .ConvertAll(video => video.GetUrl());
         }
     }
 }


### PR DESCRIPTION
This pull request adds a new configuration object to the `MusicServiceConfiguration` object for extractors. With this you can configure the max allowed duration for songs.

The `YoutubeProcessor` has been renamed to `YoutubeExtractor`.

Currently the custom length property only works for youtube videos & playlists. however I am planning on adding support for the discord processor with a future refactor where extractors will only work with url's.