### PR TITLE
Added ability to import httpclient

### DIFF
--- a/src/AudioChord/Collections/SongCollection.cs
+++ b/src/AudioChord/Collections/SongCollection.cs
@@ -118,7 +118,7 @@ namespace AudioChord.Collections
                 return retrieved;
 
             // Not in the cache, extract the audio from the url
-            IAudioExtractor extractor = new YouTubeExtractor();
+            IAudioExtractor extractor = configuration.ImportedHttpClient == null ? new YouTubeExtractor() : new YouTubeExtractor(configuration.ImportedHttpClient);
             ISong directlyDownloaded = await extractor.ExtractAsync(url, configuration);
 
             // Cache the song so that we do not need to download it again

--- a/src/AudioChord/Extractors/ExtractorConfiguration.cs
+++ b/src/AudioChord/Extractors/ExtractorConfiguration.cs
@@ -1,9 +1,11 @@
 using System;
+using System.Net.Http;
 
 namespace AudioChord.Extractors
 {
     public class ExtractorConfiguration
     {
         public TimeSpan MaxSongDuration { get; set; } = TimeSpan.FromHours(1);
+        public HttpClient? ImportedHttpClient { get; set; } = null;
     }
 }

--- a/src/AudioChord/Processors/PlaylistProcessor.cs
+++ b/src/AudioChord/Processors/PlaylistProcessor.cs
@@ -34,7 +34,7 @@ namespace AudioChord.Processors
                 ExtractorConfiguration configuration
             )
         {
-            YouTubeExtractor extractor = new YouTubeExtractor();
+            YouTubeExtractor extractor = configuration.ImportedHttpClient == null ? new YouTubeExtractor() : new YouTubeExtractor(configuration.ImportedHttpClient);
             ResolvingPlaylist playlist = new ResolvingPlaylist(ObjectId.GenerateNewId().ToString());
 
             Queue<StartableTask<ISong>> backlog = new Queue<StartableTask<ISong>>();


### PR DESCRIPTION
This adds an "ImportHttpClient" property to the extractor configuration object which will allow custom httpclient objects to be passed through.